### PR TITLE
Corrección funcionalidad botón Nueva Operación

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,20 +117,23 @@ window.addEventListener("DOMContentLoaded", () => {
 
 
 /*>>>>>>>>>>>>>>>>>>>>>>>FUNCIONAMIENTO SECCIÓN OPERACIONES<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<*/
-// BOTON NUEVA OPERACIÓN
-document.addEventListener("DOMContentLoaded", function() {
 
+document.addEventListener("DOMContentLoaded", function() {
+	// BOTON NUEVA OPERACIÓN
 	//Evento clic para:
 	botonNuevaOperacion.addEventListener("click", function() {
 
 	  // ocultar secciones
-	  contenedorBalance.classList.add("hidden");
-	  contenedorFiltros.classList.add("hidden");
 	  contenedorOperaciones.classList.add("hidden");
+	  seccionPrincipal.classList.add("hidden");
   
 	  // mostrar el formulario
 	  formularioNuevaOperacion.classList.remove("hidden");
 
 	});
+
+
+	// FUNCIONALIDAD FORMULARIO NUEVA OPERACIÓN 
+
   });
   


### PR DESCRIPTION
En este commit: 

Se cambiaron las secciones que se ocultan al hacer clic en `botonNuevaOperacion`. La propiedad **hidden** que se agregaba a `contenedorBalance` y` contenedorFiltros`, se agregó unicamente a su contendor padre que es `seccionPrincipal`. Esto solucionó el problema que impedia ocultar tanto la sección de Balance como la de Filtros cuando se mostraba el Formulario. 